### PR TITLE
Add caching for generated API docs

### DIFF
--- a/demo/docs/intro.mdx
+++ b/demo/docs/intro.mdx
@@ -202,7 +202,9 @@ The `docusaurus-plugin-openapi-docs` plugin can be configured with the following
 | `versions`           | `object`  | `null`  | _Optional:_ Options for versioning configuration. See below for a list of supported options.                                                     |
 | `markdownGenerators` | `object`  | `null`  | _Optional:_ Customize MDX content via generator functions. See below for a list of supported options.                                            |
 | `showSchemas`        | `boolean` | `null`  | _Optional:_ If set to `true`, generates standalone schema pages and adds them to the sidebar.                                                    |
-| `cache`              | `boolean` | `true`  | _Optional:_ Skip generation if the spec has not changed. |
+| `cache`              | `boolean` | `true`  | _Optional:_ Skip generation when the spec’s last modified time matches the stored metadata. |
+
+When caching is enabled, the plugin stores this timestamp in `<outputDir>/.spec-meta` and reuses the docs if the value matches on subsequent runs.
 
 ### sidebarOptions
 

--- a/demo/docs/intro.mdx
+++ b/demo/docs/intro.mdx
@@ -202,6 +202,7 @@ The `docusaurus-plugin-openapi-docs` plugin can be configured with the following
 | `versions`           | `object`  | `null`  | _Optional:_ Options for versioning configuration. See below for a list of supported options.                                                     |
 | `markdownGenerators` | `object`  | `null`  | _Optional:_ Customize MDX content via generator functions. See below for a list of supported options.                                            |
 | `showSchemas`        | `boolean` | `null`  | _Optional:_ If set to `true`, generates standalone schema pages and adds them to the sidebar.                                                    |
+| `cache`              | `boolean` | `true`  | _Optional:_ Skip generation if the spec has not changed. |
 
 ### sidebarOptions
 
@@ -254,6 +255,7 @@ petstore31: {
   downloadUrl: "/petstore-3.1.yaml",
   hideSendButton: false,
   showSchemas: true,
+  cache: true,
   markdownGenerators: { createApiPageMD: myCustomApiMdGenerator }, // customize MDX with markdown generator
 } satisfies OpenApiPlugin.Options,
 ```

--- a/demo/docs/intro.mdx
+++ b/demo/docs/intro.mdx
@@ -151,6 +151,7 @@ import type * as OpenApiPlugin from "docusaurus-plugin-openapi-docs";
       {
         id: "api", // plugin id
         docsPluginId: "classic", // configured for preset-classic
+        cache: true,
         config: {
           petstore: {
             specPath: "examples/petstore.yaml",
@@ -178,6 +179,9 @@ The `docusaurus-plugin-openapi-docs` plugin can be configured with the following
 | `id`           | `string` | `null`                            | A unique plugin ID.                                                                                                                                           |
 | `docsPlugin`   | `string` | `@docusaurus/plugin-content-docs` | The plugin used to render the OpenAPI docs (ignored if the plugin instance referenced by `docsPluginId` is a `preset`).                                       |
 | `docsPluginId` | `string` | `null`                            | The plugin ID associated with the `preset` or configured `docsPlugin` instance used to render the OpenAPI docs (e.g. "your-plugin-id", "classic", "default"). |
+| `cache`        | `boolean` | `false`                           | _Optional:_ Skip generation when the spec's last modified time matches the stored metadata. |
+
+When caching is enabled, the plugin stores this timestamp in `<outputDir>/.spec-meta` and reuses the docs if the value matches on subsequent runs.
 
 ### config
 
@@ -202,9 +206,7 @@ The `docusaurus-plugin-openapi-docs` plugin can be configured with the following
 | `versions`           | `object`  | `null`  | _Optional:_ Options for versioning configuration. See below for a list of supported options.                                                     |
 | `markdownGenerators` | `object`  | `null`  | _Optional:_ Customize MDX content via generator functions. See below for a list of supported options.                                            |
 | `showSchemas`        | `boolean` | `null`  | _Optional:_ If set to `true`, generates standalone schema pages and adds them to the sidebar.                                                    |
-| `cache`              | `boolean` | `true`  | _Optional:_ Skip generation when the spec’s last modified time matches the stored metadata. |
 
-When caching is enabled, the plugin stores this timestamp in `<outputDir>/.spec-meta` and reuses the docs if the value matches on subsequent runs.
 
 ### sidebarOptions
 
@@ -257,7 +259,6 @@ petstore31: {
   downloadUrl: "/petstore-3.1.yaml",
   hideSendButton: false,
   showSchemas: true,
-  cache: true,
   markdownGenerators: { createApiPageMD: myCustomApiMdGenerator }, // customize MDX with markdown generator
 } satisfies OpenApiPlugin.Options,
 ```

--- a/packages/docusaurus-plugin-openapi-docs/README.md
+++ b/packages/docusaurus-plugin-openapi-docs/README.md
@@ -174,6 +174,7 @@ The `docusaurus-plugin-openapi-docs` plugin can be configured with the following
 | `versions`           | `object`  | `null`  | _Optional:_ Options for versioning configuration. See below for a list of supported options.                                |
 | `markdownGenerators` | `object`  | `null`  | _Optional:_ Customize MDX content via generator functions. See below for a list of supported options.                       |
 | `showSchemas`        | `boolean` | `null`  | _Optional:_ If set to `true`, generates standalone schema pages and adds them to the sidebar.                               |
+| `cache`              | `boolean` | `true`  | _Optional:_ Skip generation if the spec has not changed.                                                                    |
 
 ### sidebarOptions
 

--- a/packages/docusaurus-plugin-openapi-docs/README.md
+++ b/packages/docusaurus-plugin-openapi-docs/README.md
@@ -174,7 +174,9 @@ The `docusaurus-plugin-openapi-docs` plugin can be configured with the following
 | `versions`           | `object`  | `null`  | _Optional:_ Options for versioning configuration. See below for a list of supported options.                                |
 | `markdownGenerators` | `object`  | `null`  | _Optional:_ Customize MDX content via generator functions. See below for a list of supported options.                       |
 | `showSchemas`        | `boolean` | `null`  | _Optional:_ If set to `true`, generates standalone schema pages and adds them to the sidebar.                               |
-| `cache`              | `boolean` | `true`  | _Optional:_ Skip generation if the spec has not changed.                                                                    |
+| `cache`              | `boolean` | `true`  | _Optional:_ Skip generation when the spec’s last modified time matches the stored metadata.                                 |
+
+When caching is enabled, the plugin stores this timestamp in `<outputDir>/.spec-meta` and reuses the docs if the value matches on subsequent runs.
 
 ### sidebarOptions
 

--- a/packages/docusaurus-plugin-openapi-docs/README.md
+++ b/packages/docusaurus-plugin-openapi-docs/README.md
@@ -123,6 +123,7 @@ import type * as OpenApiPlugin from "docusaurus-plugin-openapi-docs";
       {
         id: "api", // plugin id
         docsPluginId: "classic", // configured for preset-classic
+        cache: true,
         config: {
           petstore: {
             specPath: "examples/petstore.yaml",
@@ -145,11 +146,14 @@ import type * as OpenApiPlugin from "docusaurus-plugin-openapi-docs";
 
 The `docusaurus-plugin-openapi-docs` plugin can be configured with the following options:
 
-| Name           | Type     | Default                           | Description                                                                                                                                                   |
-| -------------- | -------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `id`           | `string` | `null`                            | A unique plugin ID.                                                                                                                                           |
-| `docsPlugin`   | `string` | `@docusaurus/plugin-content-docs` | The plugin used to render the OpenAPI docs (ignored if the plugin instance referenced by `docsPluginId` is a `preset`).                                       |
-| `docsPluginId` | `string` | `null`                            | The plugin ID associated with the `preset` or configured `docsPlugin` instance used to render the OpenAPI docs (e.g. "your-plugin-id", "classic", "default"). |
+| Name           | Type      | Default                           | Description                                                                                                                                                   |
+| -------------- | --------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`           | `string`  | `null`                            | A unique plugin ID.                                                                                                                                           |
+| `docsPlugin`   | `string`  | `@docusaurus/plugin-content-docs` | The plugin used to render the OpenAPI docs (ignored if the plugin instance referenced by `docsPluginId` is a `preset`).                                       |
+| `docsPluginId` | `string`  | `null`                            | The plugin ID associated with the `preset` or configured `docsPlugin` instance used to render the OpenAPI docs (e.g. "your-plugin-id", "classic", "default"). |
+| `cache`        | `boolean` | `false`                           | _Optional:_ Skip generation when the spec's last modified time matches the stored metadata.                                                                   |
+
+When caching is enabled, the plugin stores this timestamp in `<outputDir>/.spec-meta` and reuses the docs if the value matches on subsequent runs.
 
 ### config
 
@@ -174,9 +178,6 @@ The `docusaurus-plugin-openapi-docs` plugin can be configured with the following
 | `versions`           | `object`  | `null`  | _Optional:_ Options for versioning configuration. See below for a list of supported options.                                |
 | `markdownGenerators` | `object`  | `null`  | _Optional:_ Customize MDX content via generator functions. See below for a list of supported options.                       |
 | `showSchemas`        | `boolean` | `null`  | _Optional:_ If set to `true`, generates standalone schema pages and adds them to the sidebar.                               |
-| `cache`              | `boolean` | `true`  | _Optional:_ Skip generation when the spec’s last modified time matches the stored metadata.                                 |
-
-When caching is enabled, the plugin stores this timestamp in `<outputDir>/.spec-meta` and reuses the docs if the value matches on subsequent runs.
 
 ### sidebarOptions
 

--- a/packages/docusaurus-plugin-openapi-docs/src/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/index.ts
@@ -132,6 +132,7 @@ export default function pluginOpenAPIDocs(
     config,
     docsPlugin = "@docusaurus/plugin-content-docs",
     docsPluginId,
+    cache: enableCache = false,
   } = options;
   const { siteDir, siteConfig } = context;
 
@@ -159,7 +160,6 @@ export default function pluginOpenAPIDocs(
       downloadUrl,
       sidebarOptions,
       disableCompression,
-      cache = true,
     } = options;
 
     // Remove trailing slash before proceeding
@@ -181,7 +181,7 @@ export default function pluginOpenAPIDocs(
       const lastModified = await getSpecLastModified(contentPath);
       const metaFile = getSpecMetaPath(outputDir);
       if (
-        cache &&
+        enableCache &&
         fs.existsSync(metaFile) &&
         fs.existsSync(outputDir) &&
         fs.readFileSync(metaFile, "utf8") === String(lastModified)
@@ -526,7 +526,7 @@ custom_edit_url: null
         return;
       });
 
-      if (cache) {
+      if (enableCache) {
         try {
           fs.writeFileSync(metaFile, String(lastModified), "utf8");
         } catch (err) {

--- a/packages/docusaurus-plugin-openapi-docs/src/options.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/options.ts
@@ -31,6 +31,7 @@ export const OptionsSchema = Joi.object({
   id: Joi.string().required(),
   docsPlugin: Joi.string(),
   docsPluginId: Joi.string().required(),
+  cache: Joi.boolean(),
   config: Joi.object()
     .pattern(
       /^/,
@@ -49,7 +50,6 @@ export const OptionsSchema = Joi.object({
         markdownGenerators: markdownGenerators,
         showSchemas: Joi.boolean(),
         disableCompression: Joi.boolean(),
-        cache: Joi.boolean(),
         version: Joi.string().when("versions", {
           is: Joi.exist(),
           then: Joi.required(),

--- a/packages/docusaurus-plugin-openapi-docs/src/options.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/options.ts
@@ -49,6 +49,7 @@ export const OptionsSchema = Joi.object({
         markdownGenerators: markdownGenerators,
         showSchemas: Joi.boolean(),
         disableCompression: Joi.boolean(),
+        cache: Joi.boolean(),
         version: Joi.string().when("versions", {
           is: Joi.exist(),
           then: Joi.required(),

--- a/packages/docusaurus-plugin-openapi-docs/src/types.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/types.ts
@@ -54,7 +54,7 @@ export interface APIOptions {
   disableCompression?: boolean;
   /**
    * Enable generation caching. When true (default), docs will only
-   * regenerate when the source spec changes.
+   * regenerate when the source spec\'s last modified time changes.
    */
   cache?: boolean;
 }

--- a/packages/docusaurus-plugin-openapi-docs/src/types.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/types.ts
@@ -52,6 +52,11 @@ export interface APIOptions {
   markdownGenerators?: MarkdownGenerator;
   showSchemas?: boolean;
   disableCompression?: boolean;
+  /**
+   * Enable generation caching. When true (default), docs will only
+   * regenerate when the source spec changes.
+   */
+  cache?: boolean;
 }
 
 export interface MarkdownGenerator {

--- a/packages/docusaurus-plugin-openapi-docs/src/types.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/types.ts
@@ -26,6 +26,11 @@ export interface PluginOptions {
   id?: string;
   docsPlugin?: string;
   docsPluginId: string;
+  /**
+   * Enable generation caching across all specs. When true, docs are only
+   * regenerated when the source spec's last modified time changes.
+   */
+  cache?: boolean;
   config: {
     [key: string]: APIOptions;
   };
@@ -52,11 +57,6 @@ export interface APIOptions {
   markdownGenerators?: MarkdownGenerator;
   showSchemas?: boolean;
   disableCompression?: boolean;
-  /**
-   * Enable generation caching. When true (default), docs will only
-   * regenerate when the source spec\'s last modified time changes.
-   */
-  cache?: boolean;
 }
 
 export interface MarkdownGenerator {


### PR DESCRIPTION
This pull request introduces a caching mechanism to the `docusaurus-plugin-openapi-docs` plugin, which skips documentation generation if the source specification has not changed. The changes include updates to the plugin's configuration, implementation of the caching logic, and documentation updates. Below are the most important changes:

### Plugin Enhancements
* Added a new `cache` option to the plugin configuration, defaulting to `true`, to enable skipping generation when the source specification remains unchanged. (`packages/docusaurus-plugin-openapi-docs/src/options.ts`, `packages/docusaurus-plugin-openapi-docs/src/types.ts`, [[1]](diffhunk://#diff-19c8ea6154087d9da79010f84189d4133884ff08b5076548120027566a5cc5eaR52) [[2]](diffhunk://#diff-2c3c0edd64f88a1910345bc3be2f670f4413e92dea543c7579e70f27b4e05dcaR55-R59)
* Implemented caching logic using SHA-1 hashing to detect changes in the OpenAPI specification files. If the hash matches the previously stored value, generation is skipped, and a message is logged. (`packages/docusaurus-plugin-openapi-docs/src/index.ts`, [[1]](diffhunk://#diff-3b8bf5a58c664a5ae44947fd49163df42a3c3a1ce0de42c0116b2f5bed142683R153-R175) [[2]](diffhunk://#diff-3b8bf5a58c664a5ae44947fd49163df42a3c3a1ce0de42c0116b2f5bed142683R509-R519)
* Added cleanup functionality to remove the hash file during cleanup operations. (`packages/docusaurus-plugin-openapi-docs/src/index.ts`, [packages/docusaurus-plugin-openapi-docs/src/index.tsR577-R590](diffhunk://#diff-3b8bf5a58c664a5ae44947fd49163df42a3c3a1ce0de42c0116b2f5bed142683R577-R590))

### Documentation Updates
* Updated the plugin's README and demo documentation to include the new `cache` option and its default behavior. (`packages/docusaurus-plugin-openapi-docs/README.md`, `demo/docs/intro.mdx`, [[1]](diffhunk://#diff-9bf516ed2a3e1ef56ed62cf65207c361524ef107492880963a37538fbe86e1cdR177) [[2]](diffhunk://#diff-d82c75f33b406c052e5f2a22d1f4dea7d0cdf42c622b94ececbe3d0894797c33R205) [[3]](diffhunk://#diff-d82c75f33b406c052e5f2a22d1f4dea7d0cdf42c622b94ececbe3d0894797c33R258)

### Codebase Improvements
* Introduced a utility function `getSpecHashPath` to manage the path for the hash file. (`packages/docusaurus-plugin-openapi-docs/src/index.ts`, [packages/docusaurus-plugin-openapi-docs/src/index.tsR39-R44](diffhunk://#diff-3b8bf5a58c664a5ae44947fd49163df42a3c3a1ce0de42c0116b2f5bed142683R39-R44))
* Imported the `crypto` module for hashing functionality. (`packages/docusaurus-plugin-openapi-docs/src/index.ts`, [packages/docusaurus-plugin-openapi-docs/src/index.tsR11](diffhunk://#diff-3b8bf5a58c664a5ae44947fd49163df42a3c3a1ce0de42c0116b2f5bed142683R11))